### PR TITLE
Fancyslider: Only apply default if the number is not valid

### DIFF
--- a/be/fancyslider.js
+++ b/be/fancyslider.js
@@ -58,7 +58,8 @@
         return;
       }
 
-      if (+val || val === 0) {
+      // Default when the input is invalid
+      if (isNaN(val)) {
         val = (options.input === 'value') ? $slider.slider('value') : options.percent_default;
       }
 


### PR DESCRIPTION
This allows a user to enter a number in the textfield associated with a fancy slider. The number will be the slider's new value.

Fixes https://trello.com/c/LSBFwEX0/161-3-spacing-input-fields-don-t-seem-to-work

Also fixes Discover's color filter.